### PR TITLE
추가 사항: `MqttReconnect`를 새롭게 생성하고, 재연결 시 새로운 Client ID를 할당하도록 수정

### DIFF
--- a/src/main/java/com/nhnacademy/broker/mqtt/MqttReconnectTrigger.java
+++ b/src/main/java/com/nhnacademy/broker/mqtt/MqttReconnectTrigger.java
@@ -1,21 +1,62 @@
 package com.nhnacademy.broker.mqtt;
 
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.springframework.stereotype.Component;
 
-import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+@Slf4j
 @Component
 public final class MqttReconnectTrigger {
 
     private MqttManagement mqttManagement;
 
+    private AtomicBoolean reconnecting;
+
     public void register(MqttManagement mqttManagement) {
         this.mqttManagement = mqttManagement;
+        this.reconnecting = new AtomicBoolean(false);
     }
 
-    public void triggerReconnect() {
-        if (Objects.nonNull(mqttManagement)) {
-            mqttManagement.reconnect();
+    public void reconnection() {
+        if (mqttManagement == null) {
+            log.warn("MQTT 컴포넌트 구성 오류, 'MqttManagement'");
+            return;
+        }
+
+        if (!reconnecting.compareAndSet(false, true)) {
+            try {
+                log.info("이미 재연결을 시도 중입니다.");
+                Thread.sleep(30000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return;
+        }
+
+        new Thread(() -> {
+            try {
+                run();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            } finally {
+                reconnecting.set(false);
+            }
+        }, "mqtt-reconnect-thread").start();
+    }
+
+    private void run() throws InterruptedException {
+        while (true) {
+            try {
+                mqttManagement.close();
+                mqttManagement.init();
+                log.info("MQTT 재연결 성공");
+                break;
+            } catch (MqttException e) {
+                log.warn("MQTT 재연결 실패: {}", e.getMessage());
+            }
+            Thread.sleep(2000);
         }
     }
 }

--- a/src/main/java/com/nhnacademy/broker/mqtt/impl/MqttCallbackImpl.java
+++ b/src/main/java/com/nhnacademy/broker/mqtt/impl/MqttCallbackImpl.java
@@ -23,7 +23,7 @@ public final class MqttCallbackImpl implements MqttCallback {
 
     private final MqttExecutionContext mqttExecutionContext;
 
-    private final MqttReconnectTrigger reconnectTrigger;
+    private final MqttReconnectTrigger mqttReconnectTrigger;
 
     private final DataParserResolver parserResolver;
 
@@ -31,11 +31,11 @@ public final class MqttCallbackImpl implements MqttCallback {
 
     public MqttCallbackImpl(
             MqttExecutionContext mqttExecutionContext,
-            MqttReconnectTrigger reconnectTrigger,
+            MqttReconnectTrigger mqttReconnectTrigger,
             DataParserResolver parserResolver, ParserQueue parserQueue
     ) {
         this.mqttExecutionContext = mqttExecutionContext;
-        this.reconnectTrigger = reconnectTrigger;
+        this.mqttReconnectTrigger = mqttReconnectTrigger;
         this.parserResolver = parserResolver;
         this.parserQueue = parserQueue;
     }
@@ -46,7 +46,7 @@ public final class MqttCallbackImpl implements MqttCallback {
     @Override
     public void connectionLost(Throwable cause) {
         log.error("MQTT Client connection error: {}", cause.getMessage(), cause);
-        reconnectTrigger.triggerReconnect(); // 관리 객체에 직접 접근하지 않음
+        mqttReconnectTrigger.reconnection();
     }
 
     /**
@@ -66,9 +66,10 @@ public final class MqttCallbackImpl implements MqttCallback {
                     )
             );
         } catch (NoSuchElementException e) {
-            log.warn("{}", e.getMessage(), e);
+            log.warn("MQTT Message Arrived: {}", e.getMessage(), e);
         } catch (InterruptedException e) {
-            log.error("{}", e.getMessage(), e);
+            log.error("MQTT Message Arrived: {}", e.getMessage(), e);
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
- `MQTT` 연결 문제로 인해 문제가 발생했을 시, 재연결을 시도할 때
이전의 동일한 **Client ID**로 시도하면 게이트웨이가 해당 **Client ID**와의 연결이
문제가 없는 것처럼 오인을 하여 재연결해도 메세지가 오지 않는 문제가 발생

- `MQTT` 재연결 시 동일한 **Client ID** 사용으로 인해 메시지가 수신되지 않는 문제를 개선하기 위해서
연결 시점의 시간을 **Client ID**에 덧붙여 매번 고유한 ID로 동적으로 생성하도록 변경함.